### PR TITLE
Add audioop-lts for Python 3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "comfyui-web-viewer"
 description = "The ComfyUI Web Viewer by vrch.ai is a custom node collection offering a real-time AI-generated interactive art framework. This utility integrates realtime streaming into ComfyUI workflows, supporting keyboard control nodes, OSC control nodes, sound input nodes, and more. Accessible from any device with a web browser, it enables real time interaction with AI-generated content, making it ideal for interactive visual projects and enhancing ComfyUI workflows with efficient content management and display."
 version = "1.1.17"
 license = {file = "LICENSE"}
-dependencies = ["aiohttp","ffmpeg-python","matplotlib","pydub","python-osc","qrcode[pil]","scikit-learn","srt","websockets"]
+dependencies = ["aiohttp","ffmpeg-python","matplotlib","pydub","audioop-lts; python_version >= '3.13'","python-osc","qrcode[pil]","scikit-learn","srt","websockets"]
 
 [project.urls]
 Repository = "https://github.com/VrchStudio/comfyui-web-viewer"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ aiohttp
 ffmpeg-python
 matplotlib
 pydub
+audioop-lts; python_version >= "3.13"
 python-osc
 qrcode[pil]
 scikit-learn


### PR DESCRIPTION
## Summary
- Add `audioop-lts` as a Python 3.13+ dependency in `pyproject.toml`.
- Keep `requirements.txt` aligned for manual installs.

Fixes #5

## Validation
- Not run locally