### PR TITLE
Use ffmpeg backend for MP3 audio saves

### DIFF
--- a/nodes/audio_nodes.py
+++ b/nodes/audio_nodes.py
@@ -57,14 +57,11 @@ class VrchAudioSaverNode:
             elif waveform.dim() > 2:
                 waveform = waveform.view(waveform.size(0), -1)
 
-            # Save audio using BytesIO
-            buff = io.BytesIO()
-            torchaudio.save(buff, waveform, audio["sample_rate"], format=extension.upper())
-            buff.seek(0)
-
-            # Write BytesIO content to file
-            with open(full_path, 'wb') as f:
-                f.write(buff.getvalue())
+            audio_format = extension.lower()
+            save_kwargs = {"format": audio_format}
+            if audio_format == "mp3":
+                save_kwargs["backend"] = "ffmpeg"
+            torchaudio.save(full_path, waveform, audio["sample_rate"], **save_kwargs)
 
             results.append({
                 "filename": file_name,


### PR DESCRIPTION
## Summary
- Save audio directly to the output file instead of a `BytesIO` buffer.
- Pass the lower-case torchaudio format name.
- Force the `ffmpeg` backend for MP3 output so it does not route through `soundfile`.

Fixes #6

## Validation
- `git diff --check`
- `git diff --cached --check`
- `git diff --check HEAD~1..HEAD`
- `git show --check --stat --oneline HEAD`
- Not run locally