### PR TITLE
fix: remove unused gradio pin that breaks ComfyUI startup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ huggingface_hub
 # Music2Emotion dependencies
 chordparser==0.4.2
 fire==0.7.0
-gradio==5.40.0
 hydra-core==1.3.2
 librosa==0.10.2.post1
 mir_eval==0.8.2


### PR DESCRIPTION
## Problem

`requirements.txt` pins `gradio==5.40.0`, which requires `huggingface-hub<1.0,>=0.33.5`. When ComfyUI-Manager (or a user) installs this node's requirements, pip downgrades `huggingface-hub` to the latest 0.x (0.36.2) inside ComfyUI's Python environment.

Recent ComfyUI releases ship `transformers` 5.x, which declares `huggingface-hub>=1.5.0,<2.0` and imports `is_offline_mode` from it at startup. With 0.36.x installed, **the entire ComfyUI server fails to boot**, not just this node:

```
File "...\comfy\sd1_clip.py", line 3, in <module>
  from transformers import CLIPTokenizer
...
ImportError: cannot import name 'is_offline_mode' from 'huggingface_hub'
```

## Fix

Remove the `gradio==5.40.0` pin from `requirements.txt`.

`gradio` is not imported anywhere in this repository — verified with a case-insensitive search across the full tree, including `third_party/`; the only references are this pin and one CHANGELOG entry. So the pin is dropped entirely rather than relaxed.

If gradio is ever needed again, `gradio>=6` supports `huggingface-hub>=1.2.0,<2.0`, which is compatible with transformers 5.x.

## Environment where this was reproduced

- ComfyUI 0.28.2 (Comfy Desktop install), Python 3.13
- `transformers` 5.8.0 + `huggingface-hub` 0.36.2 → crash on startup
- Upgrading `huggingface-hub` to 1.24.0 (per transformers' requirement) fixes startup