### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ For any inquiries, you can contact us at [hi@vrch.io](mailto:hi@vrch.io?subject=
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=VrchStudio/comfyui-web-viewer&type=Date)](https://www.star-history.com/#VrchStudio/comfyui-web-viewer&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=VrchStudio/comfyui-web-viewer&type=Date)](https://star-history.dera.page/#VrchStudio/comfyui-web-viewer&Date)
 
 ## License
 


### PR DESCRIPTION
The star history chart in the README no longer renders because of GitHub stargazer API restrictions. This change points the chart to a working endpoint so it displays correctly again.